### PR TITLE
Update CMakeLists.txt to avoid linking error due to definition of USE_SMALL_INT_OPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (ISL_INT STREQUAL "imath")
   set(USE_IMATH_FOR_MP ON)
 endif ()
 
-if (ISL_SMALL_INT_OPT)
+if (ISL_SMALL_INT_OPT AND (NOT USE_GMP_FOR_MP))
   set(USE_SMALL_INT_OPT ON)
 else ()
   set(USE_SMALL_INT_OPT OFF)


### PR DESCRIPTION
See: https://github.com/Meinersbur/isl/issues/4#issuecomment-755880015