### PR TITLE
Cmake enhacements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (ISL_INT STREQUAL "imath")
   set(USE_IMATH_FOR_MP ON)
 endif ()
 
-if (ISL_SMALL_INT_OPT)
+if (ISL_SMALL_INT_OPT AND (NOT USE_GMP_FOR_MP))
   set(USE_SMALL_INT_OPT ON)
 else ()
   set(USE_SMALL_INT_OPT OFF)
@@ -409,4 +409,15 @@ add_test(NAME isl_test
 )
 add_test(NAME codegen_test
   COMMAND "${ISL_BINARY_DIR}/codegen_test.sh"
+)
+
+include(GNUInstallDirs)
+install(TARGETS isl
+  EXPORT islTargets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/isl
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
1. set USE_SMALL_INT_OPT to false if using GMP (See
   https://github.com/Meinersbur/isl/issues/4#issuecomment-755880015
2. add install directives to install library and headers to appropriate
   locations