### PR TITLE
Fuzzer and oss-fuzz initial integration

### DIFF
--- a/fuzz/fuzz_union.c
+++ b/fuzz/fuzz_union.c
@@ -1,0 +1,36 @@
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "isl/ctx.h"
+#include "isl/union_set.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	char* data_cstr = strndup(data, size);
+
+	if (data_cstr == NULL) {
+		return 0;
+	}
+
+	isl_ctx* ctx = isl_ctx_alloc();
+	isl_union_map_read_from_str(ctx, data_cstr);
+	isl_union_set_read_from_str(ctx, data_cstr);
+
+	if (size > 10) {
+		data += 5;
+		size -= 5;
+		char *data_cstr2 = strndup(data, size);
+
+		isl_union_set* tmp_set = isl_union_set_read_from_str(ctx, data_cstr);
+		isl_union_map* tmp_map = isl_union_map_read_from_str(ctx, data_cstr2);
+
+		isl_union_map_intersect_domain(tmp_map, tmp_set);
+		free(data_cstr2);
+	}
+
+	isl_ctx_free(ctx);
+	free(data_cstr);
+
+	return 0;
+}


### PR DESCRIPTION
Hi!

I have been working on getting fuzzing into isl and it would be great to get it aligned with OSS-Fuzz. OSS-Fuzz is a free service run by Google that will run the fuzzer continuously and report back with bug reports when bugs are found. These reports will have full stack traces, input triggers and more. If you are interested, then the only thing needed is an email connected to a Google account that can be used for receiving the bugs reports. I have set up an initial integration with OSS-Fuzz here: https://github.com/google/oss-fuzz/pull/6045. In order to integrate with OSS-Fuzz, I would just need an email and then get this PR merged, following that I will clean up the PR on the https://github.com/google/oss-fuzz/pull/6045 by removing the fuzzer from there.

Let me know what you think.